### PR TITLE
discover bridges using mDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ discover = Discover()
 print(discover.find_hue_bridge())
 ```
 
+Since https://discovery.meethue.com and ```discover.find_hue_bridge()``` are rate limited
+and require an internet connection, you can also search for bridges locally using mDNS:
+
+```python
+from huesdk import Discover
+discover = Discover()
+print(discover.find_hue_bridge_mdns(timeout=5))
+```
+
+
 ## Connexion
 
 ```python

--- a/huesdk/discover.py
+++ b/huesdk/discover.py
@@ -1,5 +1,16 @@
 import json
 import requests
+import socket
+import time
+from zeroconf import ServiceBrowser, ServiceListener, Zeroconf
+
+mdns_bridges = []
+
+class mDNSListener(ServiceListener):
+    def add_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        global mdns_bridges
+        info = zc.get_service_info(type_, name)
+        mdns_bridges.append(info)
 
 class Discover:
 
@@ -14,3 +25,24 @@ class Discover:
             raise Exception(result[0]["error"]["description"])        
 
         return json.dumps(result, indent=4)
+
+    def find_hue_bridge_mdns(self, timeout=5):
+        zeroconf = Zeroconf()
+        listener = mDNSListener()
+        # search for bridges
+        browser = ServiceBrowser(zeroconf, "_hue._tcp.local.", listener)
+        # wait for timeout
+        time.sleep(timeout)
+        zeroconf.close()
+        bridges = []
+        for bridge in mdns_bridges:
+            bridge_id = bridge.server.split(".")[0]
+            bridge_ip = socket.gethostbyname(bridge.server)
+            bridge_name = bridge.name.split(".")[0]
+            bridge_info = {
+                "internalipaddress": bridge_ip,
+                "id": bridge_id,
+                "name": bridge_name
+            }
+            bridges.append(bridge_info)
+        return json.dumps(bridges, indent=4)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/AlexisGomes/huesdk",
     install_requires=[
-        "requests"
+        "requests",
+        "zeroconf"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Since discovery.meethue.com is rate limited and deprecated, I have implemented a new method: find_hue_bridge_mdns(), which search for bridges on the local network with mDNS (using zeroconf), as this is the new recommended method : https://developers.meethue.com/develop/application-design-guidance/hue-bridge-discovery/