### PR TITLE
Implement needed methods for mDNSListener to prevent NotImplementedError.

### DIFF
--- a/huesdk/discover.py
+++ b/huesdk/discover.py
@@ -12,6 +12,13 @@ class mDNSListener(ServiceListener):
         info = zc.get_service_info(type_, name)
         mdns_bridges.append(info)
 
+    def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        pass
+
+    def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        pass
+
+
 class Discover:
 
     def __init__(self,discovery_url="https://discovery.meethue.com"):


### PR DESCRIPTION
This pull request prevents `NotImplementedError` from occurring during `huesdk.find_hue_bridge_mdns()`

A listener class subclassed from zeroconf's `ServiceListener` needs to implement all 3 possible methods that may get called (`add_service`, `update_service`, `remove_service`) or else the zeroconf will throw a `NotImplementedError` when a missing method is attempted to be called.

For example, when running `huesdk.find_hue_bridge_mdns(timeout=4)` I received the following error and stacktrace:
```
Exception in thread zeroconf-ServiceBrowser-_hue._tcp-5942789:
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "src/zeroconf/_services/browser.py", line 783, in zeroconf._services.browser.ServiceBrowser.run
  File "src/zeroconf/_services/browser.py", line 702, in zeroconf._services.browser._ServiceBrowserBase._fire_service_state_changed_event
  File "src/zeroconf/_services/browser.py", line 712, in zeroconf._services.browser._ServiceBrowserBase._fire_service_state_changed_event
  File "src/zeroconf/_services/__init__.py", line 56, in zeroconf._services.Signal.fire
  File "src/zeroconf/_services/browser.py", line 290, in zeroconf._services.browser._on_change_dispatcher
  File "src/zeroconf/_services/__init__.py", line 45, in zeroconf._services.ServiceListener.update_service
NotImplementedError
```

The code in this stack trace implements placeholder methods to prevent errors from occurring when those methods are called by zeroconf.