### PR TITLE
Reset mdns_bridges when at start of find_hue_bridge_mdns().

### DIFF
--- a/huesdk/discover.py
+++ b/huesdk/discover.py
@@ -27,6 +27,8 @@ class Discover:
         return json.dumps(result, indent=4)
 
     def find_hue_bridge_mdns(self, timeout=5):
+        global mdns_bridges
+        mdns_bridges = []
         zeroconf = Zeroconf()
         listener = mDNSListener()
         # search for bridges


### PR DESCRIPTION
Currently if one calls `find_hue_bridge_mdns()` multiple times, the same bridge(s) will accumulate in global variable `mdns_bridge`.  Thus calling this function multiple times creates multiple identical (redundant) entries.

This code resets `mdns_bridges` to an empty list at the beginning of each call of `find_hue_bridge_mdns()`